### PR TITLE
Fix `open::run` command on Windows

### DIFF
--- a/src/open.rs
+++ b/src/open.rs
@@ -40,7 +40,7 @@ fn run(path: &str) -> Result<&str, Vec<&str>> {
 
 #[cfg(target_os = "windows")]
 fn run(path: &str) -> Result<&str, Vec<&str>> {
-    match Command::new("cmd").arg("/C").arg("start").arg("").arg(path).status() {
+    match Command::new("cmd").arg("/C").arg("start").arg(path).status() {
         Ok(_) => Ok("cmd /C start"),
         Err(_) => Err(vec!["cmd /C start"]),
     }


### PR DESCRIPTION
Currently it tries to run the following:
```cmd
cmd /C start "" https://crates.io/crates/doc
```