### PR TITLE
Yet another try to open webpage under Windows

### DIFF
--- a/src/open.rs
+++ b/src/open.rs
@@ -40,7 +40,7 @@ fn run(path: &str) -> Result<&str, Vec<&str>> {
 
 #[cfg(target_os = "windows")]
 fn run(path: &str) -> Result<&str, Vec<&str>> {
-    match Command::new("cmd").arg("/C").arg("start").arg(path).status() {
+    match Command::new("explorer").arg(path).status() {
         Ok(_) => Ok("cmd /C start"),
         Err(_) => Err(vec!["cmd /C start"]),
     }


### PR DESCRIPTION
In continue of #2:

Under cargo go a `cmd /c start URL` does not want to work still, no idea, why - it just creates and immediately closes browser's process (std::process::Command kills its child processes in Drop?). However, the same command works well if I type it inside shell.

So I just tried an alternative way to open URL: `explorer URL`, which works for me either from Rust Command or inside cmd shell.